### PR TITLE
update markdown dependency to 6.0.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   flutter_markdown: ^0.6.6
   font_awesome_flutter: ^9.1.0
-  markdown: ^4.0.0
+  markdown: ^6.0.1
 
 dev_dependencies:
   flutter_lints: ^1.0.4


### PR DESCRIPTION
I have updated `markdown` dependency to 6.0.1 to ensure compatibility with other packages.

Thank you.